### PR TITLE
Fix arguments of Script() call.

### DIFF
--- a/code-ch06/jupyter.txt
+++ b/code-ch06/jupyter.txt
@@ -10,7 +10,7 @@ exercise2:op:OpTest:test_op_checksig
 exercise3:
 from script import Script
 
-script_pubkey = Script(0x76, 0x76, 0x95, 0x93, 0x56, 0x87)
+script_pubkey = Script([0x76, 0x76, 0x95, 0x93, 0x56, 0x87])
 script_sig = Script([])  # FILL THIS IN
 combined_script = script_sig + script_pubkey
 print(combined_script.evaluate(0))
@@ -18,7 +18,7 @@ print(combined_script.evaluate(0))
 exercise4:
 from script import Script
 
-script_pubkey = Script(0x6e, 0x87, 0x91, 0x91, 0x69, 0xa7, 0x7c, 0xa7, 0x87)
+script_pubkey = Script([0x6e, 0x87, 0x91, 0x69, 0xa7, 0x7c, 0xa7, 0x87])
 script_sig = Script([])  # FILL THIS IN
 combined_script = script_sig + script_pubkey
 print(combined_script.evaluate(0))


### PR DESCRIPTION
- argument of Script() must be list.
- In script_pubkey of exercise 4, '0x91' is duplicated.  So the script evaluated as valid when any same two items (eg. [0x53, 0x53]) in script_sig.